### PR TITLE
Add dynamic soaring to nolockstep target

### DIFF
--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -34,6 +34,8 @@ px4_add_board(
 		events
 		flight_mode_manager
 		fw_att_control
+		fw_dyn_soar_control
+		fw_dyn_soar_estimator
 		fw_pos_control_l1
 		gyro_calibration
 		gyro_fft


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since the dynamic soaring controller and estimator modules were not added to the build target, it was not possible to run them in simulation.

**Describe your solution**
This PR adds the dynamic soaring controll and estimator in the no lockstep target to be able to run it in simulation


**Test data / coverage**
To test,
```
make px4_sitl_nolockstep gazebo_plane_dynamicsoaring
```

**Additional context**
Add any other related context or media.
